### PR TITLE
add Condition operation to hybridpatch

### DIFF
--- a/Source/PatchOperations/PatchOperations/HybridPatch.cs
+++ b/Source/PatchOperations/PatchOperations/HybridPatch.cs
@@ -24,6 +24,23 @@ namespace XmlExtensions
 
         private bool DoHybridPatch(XmlNode parent, XmlNode child)
         {
+            XmlAttribute attributeCondition = child.Attributes["Condition"];
+            if (attributeCondition != null)
+            {
+                if (bool.TryParse(attributeCondition.InnerText, out bool condition))
+                {
+                    if (condition == false)
+                    {
+                        return true;
+                    }
+                }
+                else
+                {
+                    Error($"< {child.Name} > Did not receive a boolean value on Condition");
+                    return true;
+                }
+            }
+
             XmlAttribute attributeOperation = child.Attributes["Operation"];
             string operation = "Add";
             if (attributeOperation != null)


### PR DESCRIPTION
Adds ```Condition``` attribute to HybridPatch.
this would allow for a checkbox value (or any boolean for that matter) to be used in hybrid patch operations.

only ran a quick test with this to see if it would work. was tested in combination with a checkbox and using ```UseSettings``` to get the value.

would also resolve #24, the reason for creating this PR